### PR TITLE
Fixed Python package name error

### DIFF
--- a/API-Samples/Python/requirements.txt
+++ b/API-Samples/Python/requirements.txt
@@ -1,3 +1,3 @@
 requests
 azure-identity
-python-dotnet
+python-dotenv


### PR DESCRIPTION
The wrong Python package name was listed in the requirements.txt (python-dotnet instead of python-dotenv).  